### PR TITLE
Inclusão de Responsividade botão SUBIR - página Principal Index

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -1,6 +1,27 @@
 
 @media(max-width:1280px) {
 
+    .projetos .btn-subir {
+        background: none;
+        border: 1px solid #fff;
+        border-radius: 12px;
+        color: #fff;
+        width: 75px;
+        padding: 16px;
+        font-size: 14px;
+        font-weight: 600;
+        margin: 0; 
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        position: fixed; 
+        right: 20px; 
+        top: 50%; 
+        transform: translateY(-50%); 
+        z-index: 1000; 
+    }
+    
     .cabecalho {
         padding: 15px; 
         flex-direction: column; 


### PR DESCRIPTION
Foi realizado a o ajuste para que o botão "Subir" da página principal INDEX fique responsivo, de forma que se a tela do usuário for menor que 420 pixels, o botão diminua de tamanho e também a fonte, pois antes ao ficar uma tela menor, o botão estava ficando do mesmo tamanho, mesmo os outros itesn ficando responsíveis.