### PR TITLE
Alteração tamanho da Fonte do menu - página Minha Formação para telas celular (menores de 420px)

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -173,6 +173,5 @@
 
     .tab-link {
         font-size: 14px; 
-        font-size: 1555px; 
     }
 }


### PR DESCRIPTION
Foi realizado ajuste no tamanho da fonte do menu da tela MINHA FORMAÇÃO pois estava aumentando demais e estourando na página quando aberto em telas de celular menos de 420px.

Correção realizada com sucesso.