### PR TITLE
Ajuste no footer página principal

### DIFF
--- a/src/css/estilos.css
+++ b/src/css/estilos.css
@@ -392,12 +392,12 @@ body {
     padding: 25px 0;
     font-family: Arial, sans-serif;
     z-index: 1000;
-    opacity: 0; 
+    opacity: 0.7; 
     transition: opacity 1.5s ease; 
 }
 
 .footer:hover {
-    opacity: 1;
+    opacity: 1; 
 }
 
 .footer-content {


### PR DESCRIPTION
Foi ajustado o Footer da página Principal para que não mais fique desaparecido e só apareça com o passar do Mouse (hover) mas sim que fique com um leve transparência e ao passar o mouse o usuário possa ver o Footer normalmente.