### PR TITLE
Ajuste no Footer responsivo - página Principal - telas menores

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -47,6 +47,42 @@
         justify-content: center;
         align-items: center;
     }
+    
+
+    /*ajuste no footer para página pequenas*/
+    .footer {
+        position: fixed;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        background-color: rgba(8, 3, 36, 0.7); 
+        color: white;
+        text-align: center;
+        padding: 13px 0;
+        font-family: Arial, sans-serif;
+        font-size: 11px;
+        z-index: 1000;
+        opacity: 0.5; 
+        transition: opacity 1.5s ease; 
+    }
+    
+    .footer:hover {
+        opacity: 1; 
+    }
+    
+    .footer-content {
+        display: flex;
+        justify-content: space-around; 
+        align-items: center; 
+    }
+    
+    .footer p {
+        margin: 8px; 
+    }
+    
+    .footer img{
+        align-content:space-around;
+    }
 
     .menu{
         margin-top: 30px;


### PR DESCRIPTION
Foi realizado o ajuste no Footer, deixando o mesmo responsivo para telas menores de até 420px, onde o mesmo dimunui as letras e aumenta um pouco os espaços entres os itens para que sejam legíveis mesmo em telas pequenas.