### PR TITLE
Alteração do tamanho de letra dos paragrafos página minha história 420px

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -135,6 +135,10 @@
         font-size: 33px;
     }
 
+    .home .historia p{
+        font-size: 18px;
+    }
+
 
     .projetos .container-projetos{
         padding: 0 30px;


### PR DESCRIPTION
Foi realizado ajuste da letra dos parágrafos da página Minha História para que em telas com resolução de até 420px o tamanho fique harmônico com o h1 e o restante da estrutura.