### PR TITLE
Ajuste de subtítulo para h3 - Submenu cursos - Python

### DIFF
--- a/minha_formacao.html
+++ b/minha_formacao.html
@@ -57,8 +57,8 @@
                                 <a href="#" class="toggle">Programação em Python - SENAI-SP</a>
                                 <ul class="submenu">
                                     <li>
-                                        <p>
-                                            Período: Julho a Novembro 2024<br>
+                                            <h3>Período: Julho a Novembro 2024</h3><br>
+                                            <p>
                                             Conceitos de Lógica de Programação, elaboração de algorítimos para resolução
                                             de problemas,
                                             configuração de ambiente para desenvolvimento de jogos 2D utilizando

--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -186,7 +186,7 @@
     .submenu p{
         font-size: 13px;
         margin-top: 10px;
-        margin: 0px 10px;
+        margin: 0px 10px 5px;
         text-align:inherit;
     }
 


### PR DESCRIPTION
Foi realizado ajuste no subtítulo do sub menu "cursos", para ficar em destaque, além disso deixando um espaço entre ele e o texto pois antes ficavam grudados um ao outro.