### PR TITLE
Ajuste menu colapse parte 14

### DIFF
--- a/minha_formacao.html
+++ b/minha_formacao.html
@@ -57,7 +57,7 @@
                                 <a href="#" class="toggle">Programação em Python - SENAI-SP</a>
                                 <ul class="submenu">
                                     <li>
-                                            <h3>Período: Julho a Novembro 2024</h3><br>
+                                            <h4>Período: Julho a Novembro 2024</h4><br>
                                             <p>
                                             Conceitos de Lógica de Programação, elaboração de algorítimos para resolução
                                             de problemas,
@@ -72,8 +72,8 @@
                                 <a href="#" class="toggle">HTML5 - CSS3 - JavasScript Curso em Video</a>
                                 <ul class="submenu">
                                     <li>
-                                        <p>
-                                            Ano de 2022<br>
+                                            <h4>Ano de 2022</h4><br>
+                                            <p>
                                             Estudei as estruturas das Páginas WEB, conceitos de Organização e
                                             estilização WEB, bem como
                                             conhecimentos


### PR DESCRIPTION
Foi realizado o ajuste do menu colapse parte 14, onde foi melhorada a parte do menu cursos, exatamente no curso 2, onde o subtítulo que estava com tamanho e incluído dentro do parágrafo, foii retirado do mesmo e ajustado como sendo um H4 com espaçamento entre ele e o parágrafo.