### PR TITLE
Ajuste realizado no menu colapse parte 15 - Subtítulo curso colapse 3

### DIFF
--- a/minha_formacao.html
+++ b/minha_formacao.html
@@ -86,8 +86,9 @@
                                 <a href="#" class="toggle">Analista Genexus Junior 18</a>
                                 <ul class="submenu">
                                     <li>
+                                        
+                                        <h4>Janeiro 2025</h4><br>
                                         <p>
-                                            Janeiro 2025<br>
                                             Esta Certificação me proporcionou conhecimentos sólidos na Plataforma Genexus, 
                                             configuração de ambiente de Desenvolvimento KB.
                                             Aprendi conceitos e estruturas Genexus de Desenvolvimento.<br


### PR DESCRIPTION
Foi realizado neste o ajuste do subtítulo do curso da posição 3 do menu colapse, de forma que o mesmo fique com características de subtítulo pois antes estava incorporado dentro do parágrafo.