### PR TITLE
Ajustes na margin da página Minha História para telas menores

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -148,14 +148,13 @@
         max-width: 100%;
         text-align: center;
         align-items: center;
-        max-width: 87%;
+        max-width: 90%;
     }
 
     .minha-formacao {
         max-width: 100%;
         text-align: center;
         align-items: center;
-        max-width: 87%;
     }
 
     .minha-formacao h1 {
@@ -167,8 +166,12 @@
     }
 
     .home .historia p{
+        max-width: 100%;
         font-size: 18px;
-        margin: 30px
+        margin-left: 1px;
+        margin-right: 1px;
+        text-align:justify;
+        align-items: center;
     }
 
     .minha-formacao .tab-content p {


### PR DESCRIPTION
Foi realizado os ajustes na margin da página Minha História para que em telas menores como nos celulares, fique o conteúdo ajustado na tela, pois antes estava muito recuado das margins.