### PR TITLE
Retirado a margin superior da class "Home" para telas maiores.

### DIFF
--- a/src/css/estilos.css
+++ b/src/css/estilos.css
@@ -123,6 +123,7 @@ body {
   height: 100vh;
   padding: 0 20px;
   box-sizing: border-box;
+  margin-top: -135px;
 }
 
 #minha-historia {

--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -307,10 +307,6 @@
   }
 
   .home{
-    margin-top: 0px;
-  }
-
-  .home{
     margin-top: -135px;
   }
 


### PR DESCRIPTION
Retirado a margin superior da class "Home" para telas maiores, diminuindo o espeço entre o home e o Menu.
Quando o Portifólio for aberto em telas maiores ou "normais", ficará um tamanho razoável entre estes dois componentes.