### PR TITLE
Retirada de margim-top na Home em Telas médias

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -138,7 +138,7 @@
     flex-direction: column;
     align-items: center;
     gap: 30px;
-    margin-top: 35px;
+    margin-top: -135px;
   }
 
   /* .home .carrosel-imagens-historia{


### PR DESCRIPTION
Retirada de "margim-top" na classe "home" em Telas médias.
Desta forma, em telas médias diminuirá o espaço entre o menu e a class home.
Ajuste realizado com sucesso.