### PR TITLE
Ajuste de margin e padding - class "Titulo" par telas menores

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -361,6 +361,11 @@
 .timeline-section h2{
   margin: auto 1px;
 }
+
+.projetos .titulo {
+  padding: 2px 5px;
+  margin-bottom: 20px;
+}
 }
 
 


### PR DESCRIPTION
Ajuste de margin e padding da classe "titulo" para que em telas menores o espaço seja bem menor entre o h2 e container de Projetos.

Ajustes realizados com sucesso.