### PR TITLE
Ajuste de margin do home para telas menores de 430px

### DIFF
--- a/src/css/responsivo.css
+++ b/src/css/responsivo.css
@@ -416,6 +416,26 @@
 
 
 
+@media (min-width: 431px) and (max-width: 700px) {
+
+.home .informacoes h1{
+  margin-top: 130px;
+}
+ .home h2{
+  font-size: 18px;
+  margin-top: 7px;
+  margin-bottom: 1px;
+ }
+
+ .home .informacoes {
+    margin-top: 120px;
+   
+  }
+}
+
+
+
+
 
 @media (max-width: 430px) {
   


### PR DESCRIPTION
Ajuste de margin do home para telas menores de 430px.
h1 com margin maior para que fique com espaço entre ele e o menu.

Ajuste ok.